### PR TITLE
variable not initialised before use

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -10116,7 +10116,7 @@ static int get_uri_type(const char *uri)
 			if (!portbegin) {
 				return 3;
 			}
-
+			portend = portbegin + 1;
 			port = strtoul(portbegin + 1, &portend, 10);
 			if ((portend != hostend) || !port || !is_valid_port(port)) {
 				return 0;
@@ -10164,6 +10164,7 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 			if (!portbegin) {
 				port = abs_uri_protocols[i].default_port;
 			} else {
+				portend = portbegin + 1;
 				port = strtoul(portbegin + 1, &portend, 10);
 				if ((portend != hostend) || !port || !is_valid_port(port)) {
 					return 0;


### PR DESCRIPTION
Local variable portend is not initialised before use. Type of variable is char*.
Avoid errors in Source Code Checker.